### PR TITLE
Version 2.3.1

### DIFF
--- a/applications/utilities/preProcessing/faceAgglomerate/faceAgglomerate.C
+++ b/applications/utilities/preProcessing/faceAgglomerate/faceAgglomerate.C
@@ -92,6 +92,10 @@ int main(int argc, char *argv[])
             if (!pp.coupled())
             {
                 Info << "\nAgglomerating patch : " << pp.name() << endl;
+
+                // - Fatih:
+                Info << "\n\t Patch size : " << pp.size() << endl;
+
                 pairPatchAgglomeration agglomObject
                 (
                     pp,
@@ -110,11 +114,17 @@ int main(int argc, char *argv[])
     }
 
 
+    // - Fatih:
+    Info << "\nPatches not agglomerated : " << endl;
+
     // - All patches which are not agglomarated are identity for finalAgglom
     forAll(boundary, patchId)
     {
         if (finalAgglom[patchId].size() == 0)
         {
+            // - Fatih:
+            Info << "\t " << boundary[patchId].name() << endl;
+
             finalAgglom[patchId] = identity(boundary[patchId].size());
         }
     }

--- a/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.C
+++ b/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.C
@@ -40,7 +40,7 @@ void Foam::pairPatchAgglomeration::compactLevels(const label nCreatedLevels)
 bool Foam::pairPatchAgglomeration::continueAgglomerating
 (
     const label nCoarseFaces,
-    const int   minFacesForQuality
+    int   minFacesForQuality
 )
 {
     // Check the need for further agglomeration on all processors

--- a/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
+++ b/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
@@ -116,7 +116,11 @@ private:
         void compactLevels(const label fineLevelIndex);
 
         //- Check the need for further agglomeration
-        bool continueAgglomerating(const label fineLevelIndex);
+        bool continueAgglomerating
+        (
+            const label fineLevelIndex, 
+            const int minFacesForQuality
+        );
 
         //- Set edge weights
         void setEdgeWeights(const label indexLevel);

--- a/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
+++ b/src/fvAgglomerationMethods/pairPatchAgglomeration/pairPatchAgglomeration.H
@@ -119,7 +119,7 @@ private:
         bool continueAgglomerating
         (
             const label fineLevelIndex, 
-            const int minFacesForQuality
+            int minFacesForQuality
         );
 
         //- Set edge weights


### PR DESCRIPTION
Print patch size and non-agglomerated patchs. 
Modified faceAgglomerate.C under the following directory. To compile:
```
cd ${FOAM_APP}/utilities/preProcessing/faceAgglomerate
wmake
```
Declared minFacesForQuality and modified continueAgglomerating.
Modified pairPatchAgglomeration.C and .H. To compile:
```
cd ${FOAM_SRC}/fvAgglomerationMethods/pairPatchAgglomeration/
wmake libso
```